### PR TITLE
Implement Google authN support

### DIFF
--- a/.chalice/config.json
+++ b/.chalice/config.json
@@ -1,9 +1,27 @@
 {
   "stages": {
     "dev": {
-      "api_gateway_stage": "api"
+      "api_gateway_stage": "dev",
+      "environment_variables": {
+        "DSS_ENDPOINT": "https://commons-dss.ucsc-cgp-dev.org/v1"
+      }
+    },
+    "staging": {
+      "api_gateway_stage": "staging",
+      "environment_variables": {
+        "DSS_ENDPOINT": "https://commons-dss.ucsc-cgp.org/v1"
+      }
+    },
+    "prod": {
+      "api_gateway_stage": "prod",
+      "environment_variables": {
+        "DSS_ENDPOINT": "https://commons-dss.ucsc-cgp.org/v1"
+      }
     }
   }, 
   "version": "2.0", 
-  "app_name": "dos-dss-lambda"
+  "app_name": "dos-dss-lambda",
+  "environment_variables": {
+    "GOOGLE_APPLICATION_CREDENTIALS": "chalicelib/gcp-credentials.json"
+  }
 }

--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ local_client.ListDataBundles().result()
 
 For more information refer to the [Data Object Service](https://github.com/ga4gh/data-object-service-schemas).
 
+### Authentication
+
+If you're using a DSS endpoint that requires authentication, you'll need to
+include Google Cloud Platform credentials in the form of a `gcp-credentials.json`
+file. You can create that file by following steps 2 and 3
+[here](https://github.com/HumanCellAtlas/data-store#gcp).
+
+Once you have your credential file, move it to the `chalicelib/` directory so
+that it's included in the Lambda deployment package, then specify the file to
+dos-dss-lambda by setting the `GOOGLE_APPLICATION_CREDENTIALS` environment
+variable to the JSON file path (i.e. `chalicelib/gcp-credentials.json`) in
+`.chalice/config.json`.
+
 ## Development
 
 ### Status
@@ -58,7 +71,7 @@ not from DOS.
      can be a challenge.
 * Filter by URL
   *  Retrieve bundle entries by their URL to satisfy the DOS List request.
-  
+
 #### Creating BDBags using the `dss-dos-lambda`
 Using a list of DSS Data Bundles you can create a remote-file-manifest (RFM). That
 RFM is then used to create a [BDBag](https://github.com/fair-research/bdbag/blob/master/doc/config.md)
@@ -101,13 +114,13 @@ over to [the Issues](https://github.com/DataBiosphere/dos-dss-lambda/issues) to 
 * Aliases
 * Filter by URL
 
-```                                                                                         
+```
 +------------------+      +--------------+        +--------+
 | ga4gh-dos-client |------|dos-dss-lambda|--------|DSS API |
 +--------|---------+      +--------------+        +--------+
-         |                        |                                                         
-         |                        |                                                         
-         |------------------swagger.json                                                    
+         |                        |
+         |                        |
+         |------------------swagger.json
 ```
 
 We have created a lambda that creates a lightweight layer that can be used

--- a/app.py
+++ b/app.py
@@ -9,12 +9,13 @@ import requests
 import yaml
 import urlparse
 import logging
+import os
 
 from chalice import Chalice, Response
 import hca.dss
 
 # If DSS_ENDPOINT is set, make sure it doesn't have a trailing /
-DSS_ENDPOINT = 'https://commons-dss.ucsc-cgp-dev.org/v1'
+DSS_ENDPOINT = os.environ.get('DSS_ENDPOINT', 'https://commons-dss.ucsc-cgp-dev.org/v1')
 
 # tweak, which underpins the :class:`~hca.HCAConfig` object, will try to
 # create a config directory if one does not exist. This is fine if we're

--- a/app.py
+++ b/app.py
@@ -1,18 +1,17 @@
 """
-dos-indexd-lambda
-This lambda proxies requests to the necessary indexd endpoints and converts them
-to GA4GH messages.
+dos-dss-lambda
+This lambda proxies requests to the necessary DSS endpoints and converts them
+to DOS messages.
 
 """
-
-import requests
-import yaml
-import urlparse
 import logging
 import os
+import urlparse
 
 from chalice import Chalice, Response
 import hca.dss
+import requests
+import yaml
 
 # If DSS_ENDPOINT is set, make sure it doesn't have a trailing /
 DSS_ENDPOINT = os.environ.get('DSS_ENDPOINT', 'https://commons-dss.ucsc-cgp-dev.org/v1')
@@ -28,7 +27,7 @@ config = hca.HCAConfig(save_on_exit=False, autosave=False)
 config['DSSClient'].swagger_url = DSS_ENDPOINT + '/swagger.json'
 dss = hca.dss.DSSClient(config=config)
 
-app = Chalice(app_name='dos-indexd-lambda', debug=True)
+app = Chalice(app_name='dos-dss-lambda', debug=True)
 app.log.setLevel(logging.DEBUG)
 
 
@@ -84,6 +83,7 @@ def dss_list_bundle_to_dos(dss_bundle):
     #         dos_bundle['data_object_ids'].append(file['uuid'])
     return dos_bundle
 
+
 def dss_bundle_to_dos(dss_bundle):
     """
     Converts a fully formatted DSS bundle into a DOS bundle.
@@ -122,7 +122,7 @@ def make_urls(object_id, path):
     """
     replicas = ['aws', 'azure', 'gcp']
     urls = map(
-        lambda replica: {'url' : '{}/{}/{}?replica={}'.format(
+        lambda replica: {'url': '{}/{}/{}?replica={}'.format(
             DSS_ENDPOINT, path, object_id, replica)},
         replicas)
     return urls
@@ -146,6 +146,7 @@ def convert_reference_json(reference_json, data_object):
     data_object['checksums'] = [{'checksum': reference_json['crc32c'], 'type': 'crc32c'}]
     data_object['content_type'] = reference_json['content-type']
     return data_object
+
 
 @app.route('/ga4gh/dos/v1/dataobjects/{data_object_id}', methods=['GET'], cors=True)
 def get_data_object(data_object_id):
@@ -180,6 +181,7 @@ def get_data_object(data_object_id):
             except Exception as e:
                 pass
     return {'data_object': data_object}
+
 
 @app.route('/ga4gh/dos/v1/dataobjects', methods=['GET'], cors=True)
 def list_data_objects():
@@ -237,6 +239,7 @@ def list_data_bundles():
         response = e
     finally:
         return response
+
 
 @app.route('/ga4gh/dos/v1/databundles/{data_bundle_id}', methods=['GET'], cors=True)
 def get_data_bundle(data_bundle_id):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 requests
 PyYAML
 bdbag
+hca>=4.1.4,<5
+chalice>=1.6.0,<2


### PR DESCRIPTION
This PR addresses [TLP-476: Google authN support for DOS DSS Lambda](https://ucsc-cgl.atlassian.net/browse/TLP-476) by:

* Replacing the direct calls to the DSS using `requests` with the `hca` bindings to add authN support now and in preparation for future upstream authentication changes
* Making the DSS endpoint configurable
* Including minor PEP8 and naming fixes
* Adding a revised `config.json` and accompanying documentation

No unit tests are included as I anticipate [TLP-492](https://ucsc-cgl.atlassian.net/browse/TLP-492), which will bring a single, unified test suite to all of our DOS lambdas, will be completed in the next two weeks. @mikebaumann and I have manually tested these changes locally and on a deployed instance.